### PR TITLE
Update mainCI.yml

### DIFF
--- a/.github/workflows/mainCI.yml
+++ b/.github/workflows/mainCI.yml
@@ -19,7 +19,9 @@ jobs:
           node-version: '23'
 
       - name: Install dependencies
+        working-directory: spotify-analyzer
         run: npm install
 
       - name: Run tests
+        working-directory: spotify-analyzer
         run: npm test


### PR DESCRIPTION
Updating CI pipeline to install node dependencies within the spotify-analyzer directory, as build is currently failing since it cannot find package.json (this exists in in spotify-analyzer, not the root directory)