### PR TITLE
Prevent static calls

### DIFF
--- a/backend/application.properties
+++ b/backend/application.properties
@@ -1,3 +1,5 @@
 spring.data.mongodb.uri=mongodb+srv://analyzer_spotify:SpotifyAnalyzer123@cluster0.adjc17e.mongodb.net/?retryWrites=true&w=majority&appName=Cluster0
 spring.data.mongodb.database=AnalyserData
 logging.level.org.springframework.data.mongodb.core.MongoTemplate=DEBUG
+spring.mvc.throw-exception-if-no-handler-found=true
+spring.web.resources.add-mappings=false


### PR DESCRIPTION
- Server realizes there is no config for API calls without an API endpoint (e.g. /api), this causes an error to be thrown when trying to run in the server.
- This is okay because we never use call the backend without API endpoints.
- So these added lines specify that we will not be using it that way so that it knows that it is okay (this is standard practice).